### PR TITLE
バリデーションの日本語化

### DIFF
--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -146,6 +146,12 @@ return [
     |
     */
 
-    'attributes' => [],
+    'attributes' => [
+        'goal'=>'目標',
+        'now'=>'現状',
+        'why'=>'課題',
+        'action'=>'行動',
+        'deadline'=>'期限'
+    ],
 
 ];


### PR DESCRIPTION
#What
エラー文言を日本語にする

#Why
メインターゲットである日本人が使いやすくするため