### PR TITLE
フラッシュメッセージを自動非表示

### DIFF
--- a/resources/views/issue/list.blade.php
+++ b/resources/views/issue/list.blade.php
@@ -40,4 +40,10 @@ function checkDelete(){
   }
 }
 </script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+<script>
+$(function(){
+  $('.text-danger').fadeOut(2000);
+});
+</script>
 @endsection


### PR DESCRIPTION
#What
フラッシュメッセージをリロードしなくても消えるようにする

#Why
ユーザーの手間を減らすため